### PR TITLE
Fix for schema option issue #2

### DIFF
--- a/src/build-schema.ts
+++ b/src/build-schema.ts
@@ -8,7 +8,8 @@ import { getMetadata, MongooseMeta } from './meta';
  * @param {boolean} loadClass indicating if load setters + getters, static methods, and instance methods from the target class to schema
  */
 export function buildSchema(target: Function, loadClass: boolean = true) {
-  let schema: Mongoose.Schema = new Mongoose.Schema(getMetadata(target.prototype).schemaObj);
+  let meta = getMetadata(target.prototype);
+  let schema: Mongoose.Schema = new Mongoose.Schema(meta.schemaObj, meta.options);
 
   // loadClass to map setters + getters, static methods, and instance methods to schema virtuals, statics, and methods
   if (loadClass) {
@@ -47,11 +48,6 @@ function setSchemaFromMeta(target: Function, schema: Mongoose.Schema) {
     if (typeof fn.value === 'object') {
       schema.virtual(name, fn.value);
     }
-  });
-
-  // set schema level opts
-  meta.options.forEach(([option, value]: [string, any]) => {
-    schema.set(option, value);
   });
 }
 

--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -13,9 +13,7 @@ export function schema(options?: any): any {
   if (options && typeof options !== 'function') {
     return (target: Function) => {
       const meta = getMetadata(target.prototype);
-      Object.keys(options).forEach((key) => {
-        meta.options.push([key, options[key]]);
-      });
+      meta.options = options;
     };
   }
 }

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -1,6 +1,6 @@
 export interface MongooseMeta {
   schemaObj: any;
-  options: [[string, any]];
+  options: any;
   statics: [[string, any]]; // used for static properties & functions
   // queries: [[string, Function]]; // use statics instead of query
   methods: [[string, Function]];  // used for instance methods
@@ -15,7 +15,7 @@ export function getMetadata(target: MongooseClass): MongooseMeta {
   if (!target.__mongoose_meta__) {
     target.__mongoose_meta__ = <MongooseMeta>{
       schemaObj: {},
-      options: [],
+      options: {},
       statics: [],
       // queries: [],
       methods: [],


### PR DESCRIPTION
1. Changed `options` type to any in `MongooseMeta`
2. Changed the way of storing options in `schema` decorator function
3. Updated `buildSchema` function to apply schema options while schema construction